### PR TITLE
Got mathmode unicode error with < > tags fixed

### DIFF
--- a/tex2speech/Documentation/sample_input_files/basicMath.tex
+++ b/tex2speech/Documentation/sample_input_files/basicMath.tex
@@ -2,10 +2,6 @@
 \usepackage[utf8]{inputenc}
 \usepackage{amsmath}
 
-\title{Basic Math Bish Smiley Face}
-\author{Taichen Rose}
-\date{March 2021}
-
 \newtheorem{thm}{Theorem}
 \newtheorem{corr}{Corollary}
 

--- a/tex2speech/SSMLParsing/root_element.py
+++ b/tex2speech/SSMLParsing/root_element.py
@@ -14,6 +14,7 @@ class RootElement(SSMLElementNode):
             elem.text = self.getHeadText()
         if self.getTailText() != '':
             elem.tail = self.getTailText()
+
         return elem
 
     def __str__(self):
@@ -22,6 +23,7 @@ class RootElement(SSMLElementNode):
             a = '"' + self.getHeadText() + '"' + " " + a
         if self.getTailText() != "":
             a += " " + '"' + self.getTailText() + '"'
+
         return a
 
     __repr__ = __str__

--- a/tex2speech/aws_polly_render.py
+++ b/tex2speech/aws_polly_render.py
@@ -250,8 +250,6 @@ def start_polly(main, input, bibContents):
 
     masterFiles = create_master_files(main, input, bibContents)
 
-    print(masterFiles)
-
     # Create database/parser
     dbSource = open('static/pronunciation.xml')
     db = ConversionDB(dbSource.read())
@@ -259,7 +257,7 @@ def start_polly(main, input, bibContents):
 
     for master in masterFiles:
         # Expand Labels then open document
-        # tex2speech.expand_labels.expandDocNewLabels(master[0])
+        tex2speech.expand_labels.expandDocNewLabels(master[0])
         texFile = open(master[0], "r")
 
         # Call parsing here

--- a/tex2speech/conversion_parser.py
+++ b/tex2speech/conversion_parser.py
@@ -133,7 +133,6 @@ class ConversionParser:
                         if definition:
                             if 'mathmode' in definition and definition['mathmode'] == True:
                                 output = run_sympy(self._envContentsToString(envNode))
-                                print("HERE IS THE OUTPUT " + str(output))
                                 if leftChild:
                                     leftChild.appendTailText(str(output))
                                 else:
@@ -151,7 +150,7 @@ class ConversionParser:
                     offset += nextOffset
                 else:
                     self._resolveEnvironmentElements(envNode, elemList[i], elemList[i].children, None)
-                
+
                 i = (k + 1) + offset
                 if i > 0:
                     leftChild = elemList[i-1]
@@ -256,6 +255,7 @@ class ConversionParser:
 
             if insertIndex > 0:
                 leftChild = ssmlChildren[insertIndex-1]
+
         return insertIndex
 
     def _printTreeSub(self, tree, level, levelArr, atIndex, parentIndex):
@@ -283,5 +283,4 @@ class ConversionParser:
             doc = TexSoup.TexSoup(doc)
         self._parseNodes(doc.contents, tree)
         xmlTree = tree.getXMLTree()
-
-        return ET.tostring(xmlTree, encoding="unicode")
+        return ET.tostring(xmlTree, encoding="unicode", method = "text")


### PR DESCRIPTION
Due to encoding towards unicode, having XML structure which was the default method created the bug of changing < > tags to &gt and &lt. Changing the default method to text fixes this problem.