### PR TITLE
Fixed backslash bug at end

### DIFF
--- a/tex2speech/Documentation/sample_input_files/backslash.tex
+++ b/tex2speech/Documentation/sample_input_files/backslash.tex
@@ -20,4 +20,6 @@ Yes \LaTeX\
 
 \LaTeX\ no 
 
+Words are here \but\ you know \begin{equation} \end{equation}\
+
 \end{document}

--- a/tex2speech/aws_polly_render.py
+++ b/tex2speech/aws_polly_render.py
@@ -270,7 +270,7 @@ def start_polly(main, input, bibContents):
 
     for master in masterFiles:
         # Expand Labels then open document
-        # tex2speech.expand_labels.expandDocNewLabels(master[0])
+        tex2speech.expand_labels.expandDocNewLabels(master[0])
         texFile = open(master[0], "r")
 
         # Call parsing here

--- a/tex2speech/conversion_parser.py
+++ b/tex2speech/conversion_parser.py
@@ -283,4 +283,4 @@ class ConversionParser:
             doc = TexSoup.TexSoup(doc)
         self._parseNodes(doc.contents, tree)
         xmlTree = tree.getXMLTree()
-        return ET.tostring(xmlTree, encoding="unicode", method = "text")
+        return ET.tostring(xmlTree, encoding="unicode")


### PR DESCRIPTION
Got the backslash deleted at end of a word so the second word won't be a command